### PR TITLE
Backfill missing lab metadata (1 files)

### DIFF
--- a/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
+++ b/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
@@ -1,3 +1,16 @@
+---
+lab:
+  title: 'Practice Lab 1: Configure the connections for your Microsoft Graph connector'
+  description: If you're being provided with a tenant as a part of an instructor-led
+    training delivery, note that the tenant is made available to support the hands-on
+    labs in the instructor-led training.
+  duration: 116 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Microsoft Graph
+---
+
 # Practice Lab 1: Configure the connections for your Microsoft Graph connector
 
 ## WWL Tenants - Terms of Use


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 1

- `Instructions/Labs/LAB_01_configure-connections-in-admin-center.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
