### PR TITLE
Backfill missing lab metadata (1 files)

### DIFF
--- a/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
+++ b/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Practice Lab 1: Configure the connections for your Microsoft Graph connector'
   description: In this lab, you'll use the Microsoft 365 admin center to build a connection to customer files using the Microsoft File Share Connector.
-  duration: 116 minutes
+  duration: 25 minutes
   level: 200
   islab: false
   primarytopics:

--- a/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
+++ b/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
@@ -4,7 +4,7 @@ lab:
   description: In this lab, you'll use the Microsoft 365 admin center to build a connection to customer files using the Microsoft File Share Connector.
   duration: 116 minutes
   level: 200
-  islab: true
+  islab: false
   primarytopics:
     - Microsoft 365
     - Microsoft Graph

--- a/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
+++ b/Instructions/Labs/LAB_01_configure-connections-in-admin-center.md
@@ -1,3 +1,15 @@
+---
+lab:
+  title: 'Practice Lab 1: Configure the connections for your Microsoft Graph connector'
+  description: In this lab, you'll use the Microsoft 365 admin center to build a connection to customer files using the Microsoft File Share Connector.
+  duration: 116 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Microsoft 365
+    - Microsoft Graph
+---
+
 # Practice Lab 1: Configure the connections for your Microsoft Graph connector
 
 ## WWL Tenants - Terms of Use


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 1

- `Instructions/Labs/LAB_01_configure-connections-in-admin-center.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
